### PR TITLE
[DD-1248] handle batc of events in api

### DIFF
--- a/GreenArrow.Engine.Test/EventNotificationSystem/GreenArrowEventControllerTest.cs
+++ b/GreenArrow.Engine.Test/EventNotificationSystem/GreenArrowEventControllerTest.cs
@@ -19,108 +19,108 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
         }
 
         [Fact]
-        public async Task Should_handler_bounce_all_event()
+        public async Task Should_handler_bounce_all_events()
         {
             // Arrange
-            var bounceAll = _specimens.Create<BounceAll>();
+            var events = _specimens.CreateMany<BounceAll>();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
             // Act
-            await sut.PostBounceAll(bounceAll);
+            await sut.PostBounceAll(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(bounceAll), Times.Once());
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<BounceAll>()), Times.Exactly(events.Count()));
         }
 
         [Fact]
-        public async Task Should_handler_bounce_bad_address_event()
+        public async Task Should_handler_bounce_bad_address_events()
         {
             // Arrange
-            var bounceBadAddress = _specimens.Create<BounceBadAddress>();
+            var events = _specimens.CreateMany<BounceBadAddress>();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
             // Act
-            await sut.PostBounceBadAddress(bounceBadAddress);
+            await sut.PostBounceBadAddress(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(bounceBadAddress), Times.Once());
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<BounceBadAddress>()), Times.Exactly(events.Count()));
         }
 
         [Fact]
-        public async Task Should_handler_click_tracking_event()
+        public async Task Should_handler_click_tracking_events()
         {
             // Arrange
-            var clickTracking = _specimens.Create<ClickTracking>();
+            var events = _specimens.CreateMany<ClickTracking>();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
             // Act
-            await sut.PostClickTracking(clickTracking);
+            await sut.PostClickTracking(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(clickTracking), Times.Once());
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<ClickTracking>()), Times.Exactly(events.Count()));
         }
 
         [Fact]
-        public async Task Should_handler_delivery_attempt_event()
+        public async Task Should_handler_delivery_attempt_events()
         {
             // Arrange
-            var deliveryAttempt = _specimens.Create<DeliveryAttempt>();
+            var events = _specimens.CreateMany<DeliveryAttempt>();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
             // Act
-            await sut.PostDeliveryAttempt(deliveryAttempt);
+            await sut.PostDeliveryAttempt(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(deliveryAttempt), Times.Once());
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<DeliveryAttempt>()), Times.Exactly(events.Count()));
         }
 
         [Fact]
-        public async Task Should_handler_open_tracking_event()
+        public async Task Should_handler_open_tracking_events()
         {
             // Arrange
-            var openTracking = _specimens.Create<OpenTracking>();
+            var events = _specimens.CreateMany<OpenTracking>();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
             // Act
-            await sut.PostOpenTracking(openTracking);
+            await sut.PostOpenTracking(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(openTracking), Times.Once());
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<OpenTracking>()), Times.Exactly(events.Count()));
         }
 
         [Fact]
-        public async Task Should_handler_spam_complaint_event()
+        public async Task Should_handler_spam_complaint_events()
         {
             // Arrange
-            var spamComplaint = _specimens.Create<SpamComplaint>();
+            var events = _specimens.CreateMany<SpamComplaint>();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
             // Act
-            await sut.PostSpamComplaint(spamComplaint);
+            await sut.PostSpamComplaint(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(spamComplaint), Times.Once());
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<SpamComplaint>()), Times.Exactly(events.Count()));
         }
 
         [Fact]
-        public async Task Should_handler_unsubscribe_event()
+        public async Task Should_handler_unsubscribe_events()
         {
             // Arrange
-            var unsubscribe = _specimens.Create<Unsubscribe>();
+            var events = _specimens.CreateMany<Unsubscribe>();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
             // Act
-            await sut.PostUnsubscribe(unsubscribe);
+            await sut.PostUnsubscribe(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(unsubscribe), Times.Once());
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<Unsubscribe>()), Times.Exactly(events.Count()));
         }
     }
 }

--- a/GreenArrow.Engine/EventNotificationSystem/GreenArrowEventController.cs
+++ b/GreenArrow.Engine/EventNotificationSystem/GreenArrowEventController.cs
@@ -27,113 +27,134 @@ namespace GreenArrow.Engine.EventNotificationSystem
         }
 
         /// <summary>
-        /// Receive Bounce All event
+        /// Receive Bounce All events
         /// </summary>
         [Route(nameof(EventType.BounceAll))]
         [HttpPost()]
-        public async Task<IActionResult> PostBounceAll([FromBody] BounceAll bounceAll)
+        public async Task<IActionResult> PostBounceAll([FromBody] IEnumerable<BounceAll> events)
         {
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} received", EventType.BounceAll);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.BounceAll);
 
-            await _eventReceptor.HandleAsync(bounceAll);
+            foreach (var bounceAll in events)
+            {
+                await _eventReceptor.HandleAsync(bounceAll);
+            }
 
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} handled", EventType.BounceAll);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events handled", EventType.BounceAll);
 
             return Ok();
         }
 
         /// <summary>
-        /// Receive Bounce Bad Address event
+        /// Receive Bounce Bad Address events
         /// </summary>
         [Route(nameof(EventType.BounceBadAddress))]
         [HttpPost()]
-        public async Task<IActionResult> PostBounceBadAddress([FromBody] BounceBadAddress bounceBadAddress)
+        public async Task<IActionResult> PostBounceBadAddress([FromBody] IEnumerable<BounceBadAddress> events)
         {
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} received", EventType.BounceBadAddress);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.BounceBadAddress);
 
-            await _eventReceptor.HandleAsync(bounceBadAddress);
+            foreach (var bounceBadAddress in events)
+            {
+                await _eventReceptor.HandleAsync(bounceBadAddress);
+            }
 
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} handled", EventType.BounceBadAddress);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events handled", EventType.BounceBadAddress);
 
             return Ok();
         }
 
         /// <summary>
-        /// Receive Delivery Attempt event
+        /// Receive Delivery Attempt events
         /// </summary>
         [Route(nameof(EventType.DeliveryAttempt))]
         [HttpPost()]
-        public async Task<IActionResult> PostDeliveryAttempt([FromBody] DeliveryAttempt deliveryAttempt)
+        public async Task<IActionResult> PostDeliveryAttempt([FromBody] IEnumerable<DeliveryAttempt> events)
         {
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} received", EventType.DeliveryAttempt);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.DeliveryAttempt);
 
-            await _eventReceptor.HandleAsync(deliveryAttempt);
+            foreach (var deliveryAttempt in events)
+            {
+                await _eventReceptor.HandleAsync(deliveryAttempt);
+            }
 
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} handled", EventType.DeliveryAttempt);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events handled", EventType.DeliveryAttempt);
 
             return Ok();
         }
 
         /// <summary>
-        /// Receive Click Tracking event
+        /// Receive Click Tracking events
         /// </summary>
         [Route(nameof(EventType.EngineClick))]
         [HttpPost()]
-        public async Task<IActionResult> PostClickTracking([FromBody] ClickTracking clickTracking)
+        public async Task<IActionResult> PostClickTracking([FromBody] IEnumerable<ClickTracking> events)
         {
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} received", EventType.EngineClick);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.EngineClick);
 
-            await _eventReceptor.HandleAsync(clickTracking);
+            foreach (var deliveryAttempt in events)
+            {
+                await _eventReceptor.HandleAsync(deliveryAttempt);
+            }
 
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} handled", EventType.EngineClick);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events handled", EventType.EngineClick);
 
             return Ok();
         }
 
         /// <summary>
-        /// Receive Open Tracking event
+        /// Receive Open Tracking events
         /// </summary>
         [Route(nameof(EventType.EngineOpen))]
         [HttpPost()]
-        public async Task<IActionResult> PostOpenTracking([FromBody] OpenTracking openTracking)
+        public async Task<IActionResult> PostOpenTracking([FromBody] IEnumerable<OpenTracking> events)
         {
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} received", EventType.EngineOpen);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.EngineOpen);
 
-            await _eventReceptor.HandleAsync(openTracking);
+            foreach (var openTracking in events)
+            {
+                await _eventReceptor.HandleAsync(openTracking);
+            }
 
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} handled", EventType.EngineOpen);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events handled", EventType.EngineOpen);
 
             return Ok();
         }
 
         /// <summary>
-        /// Receive Spam Compaint event
+        /// Receive Spam Compaint events
         /// </summary>
         [Route(nameof(EventType.Scomp))]
         [HttpPost()]
-        public async Task<IActionResult> PostSpamComplaint([FromBody] SpamComplaint spamComplaint)
+        public async Task<IActionResult> PostSpamComplaint([FromBody] IEnumerable<SpamComplaint> events)
         {
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} received", EventType.Scomp);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.Scomp);
 
-            await _eventReceptor.HandleAsync(spamComplaint);
+            foreach (var spamComplaint in events)
+            {
+                await _eventReceptor.HandleAsync(spamComplaint);
+            }
 
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} handled", EventType.Scomp);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events handled", EventType.Scomp);
 
             return Ok();
         }
 
         /// <summary>
-        /// Receive Unsubscribe event
+        /// Receive Unsubscribe events
         /// </summary>
         [Route(nameof(EventType.EngineUnsub))]
         [HttpPost()]
-        public async Task<IActionResult> PostUnsubscribe([FromBody] Unsubscribe unsubscribe)
+        public async Task<IActionResult> PostUnsubscribe([FromBody] IEnumerable<Unsubscribe> events)
         {
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} received", EventType.EngineUnsub);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.EngineUnsub);
 
-            await _eventReceptor.HandleAsync(unsubscribe);
+            foreach (var unsubscribe in events)
+            {
+                await _eventReceptor.HandleAsync(unsubscribe);
+            }
 
-            _logger.LogDebug("Green Arrow Event {GreenArrowEventType} handled", EventType.EngineUnsub);
+            _logger.LogDebug("Green Arrow {GreenArrowEventType} events handled", EventType.EngineUnsub);
 
             return Ok();
         }


### PR DESCRIPTION
As default, _Green Arrow_ POST batches of events when in Event Processor, could be changes to POST single event, but the recommendation is do it in batch for improve the performance