### PR TITLE
[DD-1248] use  concrete list as parameter type

### DIFF
--- a/GreenArrow.Engine.Test/EventNotificationSystem/GreenArrowEventControllerTest.cs
+++ b/GreenArrow.Engine.Test/EventNotificationSystem/GreenArrowEventControllerTest.cs
@@ -22,7 +22,7 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
         public async Task Should_handler_bounce_all_events()
         {
             // Arrange
-            var events = _specimens.CreateMany<BounceAll>();
+            var events = _specimens.CreateMany<BounceAll>().ToList();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
@@ -30,14 +30,14 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
             await sut.PostBounceAll(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<BounceAll>()), Times.Exactly(events.Count()));
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<BounceAll>()), Times.Exactly(events.Count));
         }
 
         [Fact]
         public async Task Should_handler_bounce_bad_address_events()
         {
             // Arrange
-            var events = _specimens.CreateMany<BounceBadAddress>();
+            var events = _specimens.CreateMany<BounceBadAddress>().ToList();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
@@ -45,14 +45,14 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
             await sut.PostBounceBadAddress(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<BounceBadAddress>()), Times.Exactly(events.Count()));
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<BounceBadAddress>()), Times.Exactly(events.Count));
         }
 
         [Fact]
         public async Task Should_handler_click_tracking_events()
         {
             // Arrange
-            var events = _specimens.CreateMany<ClickTracking>();
+            var events = _specimens.CreateMany<ClickTracking>().ToList();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
@@ -60,14 +60,14 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
             await sut.PostClickTracking(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<ClickTracking>()), Times.Exactly(events.Count()));
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<ClickTracking>()), Times.Exactly(events.Count));
         }
 
         [Fact]
         public async Task Should_handler_delivery_attempt_events()
         {
             // Arrange
-            var events = _specimens.CreateMany<DeliveryAttempt>();
+            var events = _specimens.CreateMany<DeliveryAttempt>().ToList();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
@@ -75,14 +75,14 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
             await sut.PostDeliveryAttempt(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<DeliveryAttempt>()), Times.Exactly(events.Count()));
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<DeliveryAttempt>()), Times.Exactly(events.Count));
         }
 
         [Fact]
         public async Task Should_handler_open_tracking_events()
         {
             // Arrange
-            var events = _specimens.CreateMany<OpenTracking>();
+            var events = _specimens.CreateMany<OpenTracking>().ToList();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
@@ -90,14 +90,14 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
             await sut.PostOpenTracking(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<OpenTracking>()), Times.Exactly(events.Count()));
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<OpenTracking>()), Times.Exactly(events.Count));
         }
 
         [Fact]
         public async Task Should_handler_spam_complaint_events()
         {
             // Arrange
-            var events = _specimens.CreateMany<SpamComplaint>();
+            var events = _specimens.CreateMany<SpamComplaint>().ToList();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
@@ -105,14 +105,14 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
             await sut.PostSpamComplaint(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<SpamComplaint>()), Times.Exactly(events.Count()));
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<SpamComplaint>()), Times.Exactly(events.Count));
         }
 
         [Fact]
         public async Task Should_handler_unsubscribe_events()
         {
             // Arrange
-            var events = _specimens.CreateMany<Unsubscribe>();
+            var events = _specimens.CreateMany<Unsubscribe>().ToList();
             var eventReceptoMock = new Mock<IEventReceptor>();
             var sut = CreateSut(eventReceptoMock.Object);
 
@@ -120,7 +120,7 @@ namespace GreenArrow.Engine.Test.EventNotificationSystem
             await sut.PostUnsubscribe(events);
 
             // Assert
-            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<Unsubscribe>()), Times.Exactly(events.Count()));
+            eventReceptoMock.Verify(x => x.HandleAsync(It.IsAny<Unsubscribe>()), Times.Exactly(events.Count));
         }
     }
 }

--- a/GreenArrow.Engine/EventNotificationSystem/GreenArrowEventController.cs
+++ b/GreenArrow.Engine/EventNotificationSystem/GreenArrowEventController.cs
@@ -31,7 +31,7 @@ namespace GreenArrow.Engine.EventNotificationSystem
         /// </summary>
         [Route(nameof(EventType.BounceAll))]
         [HttpPost()]
-        public async Task<IActionResult> PostBounceAll([FromBody] IEnumerable<BounceAll> events)
+        public async Task<IActionResult> PostBounceAll([FromBody] List<BounceAll> events)
         {
             _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.BounceAll);
 
@@ -50,7 +50,7 @@ namespace GreenArrow.Engine.EventNotificationSystem
         /// </summary>
         [Route(nameof(EventType.BounceBadAddress))]
         [HttpPost()]
-        public async Task<IActionResult> PostBounceBadAddress([FromBody] IEnumerable<BounceBadAddress> events)
+        public async Task<IActionResult> PostBounceBadAddress([FromBody] List<BounceBadAddress> events)
         {
             _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.BounceBadAddress);
 
@@ -69,7 +69,7 @@ namespace GreenArrow.Engine.EventNotificationSystem
         /// </summary>
         [Route(nameof(EventType.DeliveryAttempt))]
         [HttpPost()]
-        public async Task<IActionResult> PostDeliveryAttempt([FromBody] IEnumerable<DeliveryAttempt> events)
+        public async Task<IActionResult> PostDeliveryAttempt([FromBody] List<DeliveryAttempt> events)
         {
             _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.DeliveryAttempt);
 
@@ -88,7 +88,7 @@ namespace GreenArrow.Engine.EventNotificationSystem
         /// </summary>
         [Route(nameof(EventType.EngineClick))]
         [HttpPost()]
-        public async Task<IActionResult> PostClickTracking([FromBody] IEnumerable<ClickTracking> events)
+        public async Task<IActionResult> PostClickTracking([FromBody] List<ClickTracking> events)
         {
             _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.EngineClick);
 
@@ -107,7 +107,7 @@ namespace GreenArrow.Engine.EventNotificationSystem
         /// </summary>
         [Route(nameof(EventType.EngineOpen))]
         [HttpPost()]
-        public async Task<IActionResult> PostOpenTracking([FromBody] IEnumerable<OpenTracking> events)
+        public async Task<IActionResult> PostOpenTracking([FromBody] List<OpenTracking> events)
         {
             _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.EngineOpen);
 
@@ -126,7 +126,7 @@ namespace GreenArrow.Engine.EventNotificationSystem
         /// </summary>
         [Route(nameof(EventType.Scomp))]
         [HttpPost()]
-        public async Task<IActionResult> PostSpamComplaint([FromBody] IEnumerable<SpamComplaint> events)
+        public async Task<IActionResult> PostSpamComplaint([FromBody] List<SpamComplaint> events)
         {
             _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.Scomp);
 
@@ -145,7 +145,7 @@ namespace GreenArrow.Engine.EventNotificationSystem
         /// </summary>
         [Route(nameof(EventType.EngineUnsub))]
         [HttpPost()]
-        public async Task<IActionResult> PostUnsubscribe([FromBody] IEnumerable<Unsubscribe> events)
+        public async Task<IActionResult> PostUnsubscribe([FromBody] List<Unsubscribe> events)
         {
             _logger.LogDebug("Green Arrow {GreenArrowEventType} events received", EventType.EngineUnsub);
 


### PR DESCRIPTION
The controller parameter must be a concrete class than can be created when receive the parameter